### PR TITLE
CCSDT with CCSD subiterations

### DIFF
--- a/src/cc/cc4.cxx
+++ b/src/cc/cc4.cxx
@@ -321,6 +321,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/ccd.cxx
+++ b/src/cc/ccd.cxx
@@ -147,6 +147,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/ccsd.cxx
+++ b/src/cc/ccsd.cxx
@@ -270,6 +270,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/ccsdipgf.cxx
+++ b/src/cc/ccsdipgf.cxx
@@ -273,6 +273,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 150,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 krylov?

--- a/src/cc/ccsdt.hpp
+++ b/src/cc/ccsdt.hpp
@@ -30,6 +30,7 @@ class CCSDT : public Iterative<U>
         bool run(task::TaskDAG& dag, const Arena& arena);
 
         void iterate(const Arena& arena);
+        void subiterate(const Arena& arena);
 
         /*
         double getProjectedS2() const;

--- a/src/cc/ccsdtq.cxx
+++ b/src/cc/ccsdtq.cxx
@@ -357,6 +357,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 guess?

--- a/src/cc/eomeeccsd.cxx
+++ b/src/cc/eomeeccsd.cxx
@@ -397,6 +397,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 150,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 davidson?

--- a/src/cc/eomeeccsdt.cxx
+++ b/src/cc/eomeeccsdt.cxx
@@ -407,6 +407,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 150,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 davidson?

--- a/src/cc/lambdacc4.cxx
+++ b/src/cc/lambdacc4.cxx
@@ -358,6 +358,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lambdaccsd.cxx
+++ b/src/cc/lambdaccsd.cxx
@@ -134,6 +134,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lambdaccsdt.cxx
+++ b/src/cc/lambdaccsdt.cxx
@@ -210,6 +210,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lambdaccsdt_q.cxx
+++ b/src/cc/lambdaccsdt_q.cxx
@@ -263,6 +263,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lambdaccsdtq.cxx
+++ b/src/cc/lambdaccsdtq.cxx
@@ -357,6 +357,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lambdaccsdtq_1a.cxx
+++ b/src/cc/lambdaccsdtq_1a.cxx
@@ -262,6 +262,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lambdaccsdtq_3.cxx
+++ b/src/cc/lambdaccsdtq_3.cxx
@@ -344,6 +344,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/lccd.cxx
+++ b/src/cc/lccd.cxx
@@ -118,6 +118,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/piccsd.cxx
+++ b/src/cc/piccsd.cxx
@@ -275,6 +275,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/rhfccsd.cxx
+++ b/src/cc/rhfccsd.cxx
@@ -335,6 +335,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/cc/rhfeomeeccsd.cxx
+++ b/src/cc/rhfeomeeccsd.cxx
@@ -434,6 +434,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 150,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 davidson?

--- a/src/cc/upsilonccsd.cxx
+++ b/src/cc/upsilonccsd.cxx
@@ -133,6 +133,8 @@ convergence?
     double 1e-9,
 max_iterations?
     int 50,
+sub_iterations?
+    int 0,
 conv_type?
     enum { MAXE, RMSE, MAE },
 diis?

--- a/src/scf/aouhf.cxx
+++ b/src/scf/aouhf.cxx
@@ -271,6 +271,8 @@ static const char* spec = R"(
         double 1e-12,
     max_iterations?
         int 150,
+    sub_iterations?
+        int 0,
     conv_type?
         enum { MAXE, RMSE, MAE },
     diis?

--- a/src/util/iterative.hpp
+++ b/src/util/iterative.hpp
@@ -21,7 +21,9 @@ class Iterative : public task::Task
         vector<double> conv_;
         double convtol;
         int iter_;
+        int subiter_;
         int maxiter;
+        int maxsubiter;
         int nsolution_;
 
         static ConvergenceType getConvType(const input::Config& config)
@@ -71,7 +73,7 @@ class Iterative : public task::Task
             assert(i >= 0 && i < conv_.size());
             return conv_[i];
         }
-
+        
         const U& energy() const
         {
             assert(energy_.size() == 1);
@@ -106,16 +108,30 @@ class Iterative : public task::Task
             return iter_;
         }
 
+        int subiter() const
+        {
+            return subiter_;
+        }
+
         virtual void iterate(const Arena& arena) = 0;
+
+        virtual void subiterate(const Arena& arena) 
+        {
+            if (config.get<int>("sub_iterations") != 0 )
+            {
+                return;
+            }
+        }
 
     public:
         Iterative(const string& name, input::Config& config)
         : Task(name, config),
           convtol(config.get<double>("convergence")),
           maxiter(config.get<int>("max_iterations")),
+          maxsubiter(config.get<int>("sub_iterations")),
           nsolution_(0),
           convtype(getConvType(config)) {}
-
+        
         virtual ~Iterative() {}
 
         bool run(task::TaskDAG& dag, const Arena& arena)
@@ -125,18 +141,41 @@ class Iterative : public task::Task
 
         bool run(task::TaskDAG& dag, const Arena& arena, int nsolution)
         {
+            log(arena) << config.get<int>("sub_iterations") << endl;
             nsolution_ = nsolution;
             energy_.resize(nsolution);
             conv_.assign(nsolution, numeric_limits<double>::max());
-
+            
             for (iter_ = 1;iter_ <= maxiter && !isConverged();iter_++)
             {
+                for (subiter_ = 1;subiter_ <= maxsubiter && !isConverged();subiter_++)
+                {
+                    time::Timer timer;
+                    timer.start();
+                    subiterate(arena);
+                    timer.stop();
+                    double dt = timer.seconds(arena);
+                    log(arena) << "Subiteration " << iter_ << "." << subiter_ << " took " << fixed <<
+                               setprecision(3) << dt << " s" << endl;
+                    for (int i = 0;i < nsolution;i++)
+                    {
+                        if (nsolution > 1)
+                        {
+                            log(arena) << "Subiteration " << iter_ << "." << subiter_ << " sol'n " << (i+1) <<
+                                          " energy = " << printToAccuracy(energy_[i], convtol)  << endl;
+                        }
+                        else
+                        {
+                            log(arena) << "Subteration " << iter_ << "." << subiter_ <<
+                                          " energy = " << printToAccuracy(energy_[i], convtol) << endl;
+                        }
+                    }
+                }
                 time::Timer timer;
                 timer.start();
                 iterate(arena);
                 timer.stop();
                 double dt = timer.seconds(arena);
-
                 log(arena) << "Iteration " << iter_ << " took " << fixed <<
                               setprecision(3) << dt << " s" << endl;
 
@@ -155,6 +194,7 @@ class Iterative : public task::Task
                                       ", convergence = " << scientific << setprecision(3) << conv_[i] << endl;
                     }
                 }
+
             }
 
             if (!isConverged())


### PR DESCRIPTION
Changes to src/cc/ccsdt.cxx and src/util/iterative.hpp  to allow for any number of ccsd (plus t3->t1 and t->2 contributions) subiterations during the ccsdt routine.