### PR TITLE
add latest Fortran MPI library name

### DIFF
--- a/m4/ax_prog_f77_mpi.m4
+++ b/m4/ax_prog_f77_mpi.m4
@@ -93,7 +93,7 @@ AS_IF([test x"$_ax_prog_f77_mpi_mpi_wanted" = xno],
     # We do not use AC_SEARCH_LIBS here, as it caches its outcome and
     # thus disallows corresponding calls in the other AX_PROG_*_MPI
     # macros.
-    for lib in NONE fmpi fmpich; do
+    for lib in NONE mpifort fmpi fmpich; do
       save_LIBS=$LIBS
       if test x"$lib" = xNONE; then
         AC_MSG_CHECKING([for function MPI_INIT])

--- a/m4/ax_prog_fc_mpi.m4
+++ b/m4/ax_prog_fc_mpi.m4
@@ -93,7 +93,7 @@ AS_IF([test x"$_ax_prog_fc_mpi_mpi_wanted" = xno],
     # We do not use AC_SEARCH_LIBS here, as it caches its outcome and
     # thus disallows corresponding calls in the other AX_PROG_*_MPI
     # macros.
-    for lib in NONE mpichf90 fmpi fmpich; do
+    for lib in NONE mpifort mpichf90 fmpi fmpich; do
       save_LIBS=$LIBS
       if test x"$lib" = xNONE; then
         AC_MSG_CHECKING([for function MPI_INIT])


### PR DESCRIPTION
Both MPICH and Open-MPI have converged on `libmpifort` as the Fortran library name...
```
$ mpifort -show
ifort -g -Wl,-flat_namespace -Wl,-commons,use_dylibs -I/opt/mpich/dev/intel/default/include \
-I/opt/mpich/dev/intel/default/include -L/opt/mpich/dev/intel/default/lib \
-lmpifort -lmpi -lpmpi
```