### PR TITLE
Use main CTF repository.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AS_IF([test $sgemm = SGEMM_], [AC_DEFINE([F77_NAME], [UPPER_UNDERSCORE], [Type o
 #
 # Configure CTF
 #
-AQ_WITH_PACKAGE([CTF], [https://github.com/solomonik/ctf],
+AQ_WITH_PACKAGE([CTF], [https://github.com/cyclops-community/ctf],
                 [ctf.hpp], [],
                 [CTF_linked], [-lctf])
 AM_CONDITIONAL([CTF_IS_LOCAL], [test x"$ctf_INCLUDES" = x" -Isrc/external/ctf/include"])


### PR DESCRIPTION
This PR switches over to the main CTF repository, since the code in the solomonik repo doesn't compile with GCC 9.2.1.